### PR TITLE
Disconnected Network enablement [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*~
+.cache/
+/bin
+/bundle
+/bundle_tmp*
+/bundle.Dockerfile
+

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ bundle: kustomize ## Generate bundle manifests and metadata, then validate gener
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	cd config/manifests/bases && python inject-custom-config.py
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
+++ b/config/crd/bases/tower.ansible.com_ansiblejobs.yaml
@@ -34,6 +34,12 @@ spec:
                 type: string
               tower_auth_secret:
                 type: string
+              runner_image:
+                type: string
+                description: Runner image used when running jobs
+              runner_version:
+                type: string
+                description: Runner image version used when running jobs
             required:
             - tower_auth_secret
             - job_template_name

--- a/config/manifests/bases/annotations.yaml
+++ b/config/manifests/bases/annotations.yaml
@@ -1,0 +1,2 @@
+annotations:
+  operators.openshift.io/infrastructure-features: '["disconnected"]'

--- a/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-resource-operator.clusterserviceversion.yaml
@@ -1,0 +1,56 @@
+apiVersion: operators.coreos.com/v1beta1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+    categories: Integration & Delivery,OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/open-cluster-management/platform-resource-operator:latest
+    description: The Ansible Automation Platform Resource Operator manages launching
+      Ansible Jobs and Workflows.
+    repository: https://github.com/ansible/awx-resource-operator
+    support: Red Hat
+  name: awx-resource-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions: {}
+  description: The Ansible Automation Platform Resource Operator manages launching
+    Ansible Jobs and Workflows.
+  displayName: AWX Resource Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - automation
+  - ansible
+  - tower
+  - awx
+  - resource
+  - ci
+  - cd
+  links:
+  - name: Awx Operator
+    url: https://github.com/ansible/awx-resource-operator
+  maintainers:
+  - email: ocm-dev@open-cluster-management.io
+    name: Open Cluster Management Project team
+  maturity: alpha
+  provider:
+    name: Red Hat
+    url: github.com/ansible/awx-resource-operator
+  version: 0.0.0

--- a/config/manifests/bases/inject-custom-config.py
+++ b/config/manifests/bases/inject-custom-config.py
@@ -1,0 +1,22 @@
+'''
+After generating the bundle, inject custom configuration such as
+annotations, OLM parameters, etc.
+'''
+
+import yaml
+
+annotations_path = "../../../bundle/metadata/annotations.yaml"
+existing_annotations = open(annotations_path, 'r')
+annotations = yaml.safe_load(existing_annotations)
+
+
+raw_annotations = open("annotations.yaml")
+base_annotations = yaml.safe_load(raw_annotations)
+
+# Inject custom annotations
+annotations['annotations'].update(base_annotations['annotations'])
+
+file_content = yaml.safe_dump(annotations, default_flow_style=False, explicit_start=True)
+
+with open(annotations_path, 'w') as f:
+    f.write(file_content)

--- a/config/samples/tower_v1alpha1_ansiblejob.yaml
+++ b/config/samples/tower_v1alpha1_ansiblejob.yaml
@@ -1,7 +1,8 @@
 apiVersion: tower.ansible.com/v1alpha1
 kind: AnsibleJob
 metadata:
-  generateName: demo-job- # generate a unique suffix per 'kubectl create'
+  name: demo-job
+  # generateName: demo-job- # generate a unique suffix per 'kubectl create'
 spec:
   tower_auth_secret: toweraccess
   job_template_name: Demo Job Template

--- a/roles/job/tasks/main.yml
+++ b/roles/job/tasks/main.yml
@@ -35,6 +35,17 @@
       - tower_config_secret["resources"] is defined and (tower_config_secret["resources"]|length>0)
     fail_msg: "Tower Secret must exist"
 
+- name: Set user provided runner image
+  set_fact:
+    _custom_runner_image: "{{ runner_image }}:{{ runner_version }}"
+  when:
+    - runner_image is defined
+    - runner_version is defined
+
+- name: Set Runner image URL
+  set_fact:
+    _runner_image: "{{ _custom_runner_image | default(lookup('env', 'RELATED_IMAGE_ANSIBLE_JOB_RUNNER_IMAGE')) }}"
+
 - name: Start K8s Runner Job
   k8s:
     state: present

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -11,7 +11,8 @@ spec:
       serviceAccountName: awx-resource-operator-controller-manager
       containers:
         - name: "{{ ansible_operator_meta.name }}"
-          image: "{{ lookup('env', 'RELATED_IMAGE_ANSIBLE_JOB_RUNNER_IMAGE') }}"
+          image: "{{ _runner_image }}"
+          imagePullPolicy: Always
           env:
             - name: TOWER_OAUTH_TOKEN
               value: "{{ tower_config_secret['resources'][0]['data']['token'] | b64decode }}"


### PR DESCRIPTION
By following [these docs](https://docs.openshift.com/container-platform/4.3/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs) I have added the necessary changes to be able to deploy this operator in a disconnected environment that has a mirrored registry set up.  

* Add CSV (may be generated downstream later instead)
* Add relatedImages

The docs state that we should be referencing these images with SHA's, which will mean manual updates for releases.  